### PR TITLE
Use CultureInfo.InvariantCulture when parsing Decimal

### DIFF
--- a/Args.Tests/OrdinalModelBindingTests.cs
+++ b/Args.Tests/OrdinalModelBindingTests.cs
@@ -2,6 +2,7 @@
 using SharpTestsEx;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -47,7 +48,7 @@ namespace Args.Tests
 
             c.Name.Should().Be.EqualTo(args[0]);
             c.Count.Should().Be.EqualTo(int.Parse(args[1]));
-            c.Value.Should().Be.EqualTo(decimal.Parse(args[2]));
+            c.Value.Should().Be.EqualTo(decimal.Parse(args[2], CultureInfo.InvariantCulture));
         }
 
         [Test]

--- a/Args/MemberBindingDefinition.cs
+++ b/Args/MemberBindingDefinition.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Collections;
+using System.Globalization;
 
 namespace Args
 {
@@ -68,7 +69,7 @@ namespace Args
                     if (typeConverter.CanConvertFrom(typeof(string)) == false)
                         throw new InvalidOperationException(String.Format(Properties.Resources.TypeConverterNotFoundMessage, typeof(string).Name, collectionType.Name));
 
-                    var convertedValues = value.Select(typeConverter.ConvertFrom);
+                    var convertedValues = value.Select(v => typeConverter.ConvertFrom(null, CultureInfo.InvariantCulture, v));
 
                     if (declaredType.IsAssignableFrom(collectionType.MakeArrayType()))
                         newValue = convertedValues.ToArray().Convert(collectionType);
@@ -93,7 +94,7 @@ namespace Args
                 if (String.IsNullOrEmpty(joinedValue) && declaredType == typeof(bool))
                     joinedValue = true.ToString();
 
-                newValue = typeConverter.ConvertFrom(joinedValue);
+                newValue = typeConverter.ConvertFrom(null, CultureInfo.InvariantCulture, joinedValue);
             }
 
             if (newValue == declaredType.GetDefaultValue() && DefaultValue != null) newValue = DefaultValue;


### PR DESCRIPTION
This PR fixes a few tests that fail due to parsing `decimal` with `.` as the decimal separator without specifying `CultureInfo.InvariantCulture`. Norwegian culture uses `,` as the decimal separator, for instance.
